### PR TITLE
Add Polygon Selector Support 

### DIFF
--- a/demo/src/components/Samples/Multiple/index.js
+++ b/demo/src/components/Samples/Multiple/index.js
@@ -3,7 +3,8 @@ import Annotation from '../../../../../src'
 import {
   PointSelector,
   RectangleSelector,
-  OvalSelector
+  OvalSelector,
+  PolygonSelector
 } from '../../../../../src/selectors'
 
 import Button from '../../Button'
@@ -64,6 +65,12 @@ export default class Multiple extends Component {
           active={OvalSelector.TYPE === this.state.type}
         >
           {OvalSelector.TYPE}
+        </Button>
+        <Button
+          onClick={this.onChangeType}
+          active={PolygonSelector.TYPE === this.state.type}
+        >
+          {PolygonSelector.TYPE}
         </Button>
 
         <Annotation

--- a/demo/src/components/Samples/Simple/index.js
+++ b/demo/src/components/Samples/Simple/index.js
@@ -1,13 +1,16 @@
 import React, { Component } from 'react'
 import Annotation from '../../../../../src'
 
+import PolygonSelector from '../../../../../src/hocs/PolygonSelector'
+
 import Root from '../../Root'
 import img from '../../../img.jpeg'
 
 export default class Simple extends Component {
   state = {
     annotations: [],
-    annotation: {}
+    annotation: {},
+    type: PolygonSelector.TYPE
   }
 
   onChange = (annotation) => {

--- a/demo/src/components/Samples/Simple/index.js
+++ b/demo/src/components/Samples/Simple/index.js
@@ -1,16 +1,13 @@
 import React, { Component } from 'react'
 import Annotation from '../../../../../src'
 
-import PolygonSelector from '../../../../../src/hocs/PolygonSelector'
-
 import Root from '../../Root'
 import img from '../../../img.jpeg'
 
 export default class Simple extends Component {
   state = {
     annotations: [],
-    annotation: {},
-    type: PolygonSelector.TYPE
+    annotation: {}
   }
 
   onChange = (annotation) => {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
+    "point-in-polygon": "^1.0.1",
+    "polygon-tools": "^0.4.8",
+    "react-lineto": "^3.1.2",
     "styled-components": "^3.1.6"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
-    "point-in-polygon": "^1.0.1",
+    "polygon-lookup": "^2.4.0",
     "polygon-tools": "^0.4.8",
     "react-lineto": "^3.1.2",
     "styled-components": "^3.1.6"

--- a/src/components/Annotation.js
+++ b/src/components/Annotation.js
@@ -269,7 +269,8 @@ export default compose(
             })
           )
         }
-        {props.value.geometry
+        {props.value
+          && props.value.geometry
           && (props.value.geometry.type === PolygonSelector.TYPE)
           && (!props.value.selection || !props.value.selection.showEditor)
           && (

--- a/src/components/Annotation.js
+++ b/src/components/Annotation.js
@@ -5,6 +5,8 @@ import compose from '../utils/compose'
 import isMouseHovering from '../utils/isMouseHovering'
 import withRelativeMousePos from '../utils/withRelativeMousePos'
 
+import { PolygonSelector } from '../selectors'
+
 import defaultProps from './defaultProps'
 import Overlay from './Overlay'
 
@@ -42,6 +44,9 @@ export default compose(
     onMouseDown: T.func,
     onMouseMove: T.func,
     onClick: T.func,
+    // For Polygon Selector
+    onSelectionComplete: T.func,
+    onSelectionClear: T.func,
 
     annotations: T.arrayOf(
       T.shape({
@@ -81,7 +86,8 @@ export default compose(
     renderContent: T.func.isRequired,
 
     disableOverlay: T.bool,
-    renderOverlay: T.func.isRequired
+    renderOverlay: T.func.isRequired,
+    renderPolygonControls: T.func.isRequired
   }
 
   static defaultProps = defaultProps
@@ -135,6 +141,8 @@ export default compose(
   onMouseDown = (e) => this.callSelectorMethod('onMouseDown', e)
   onMouseMove = (e) => this.callSelectorMethod('onMouseMove', e)
   onClick = (e) => this.callSelectorMethod('onClick', e)
+  onSelectionComplete = () => this.callSelectorMethod('onSelectionComplete')
+  onSelectionClear = () => this.callSelectorMethod('onSelectionClear')
 
   onSubmit = () => {
     this.props.onSubmit(this.props.value)
@@ -187,7 +195,8 @@ export default compose(
       renderContent,
       renderSelector,
       renderEditor,
-      renderOverlay
+      renderOverlay,
+      renderPolygonControls
     } = props
 
     const topAnnotationAtMouse = this.getTopAnnotationAt(
@@ -257,6 +266,17 @@ export default compose(
               annotation: props.value,
               onChange: props.onChange,
               onSubmit: this.onSubmit
+            })
+          )
+        }
+        {props.value.geometry
+          && (props.value.geometry.type === PolygonSelector.TYPE)
+          && (!props.value.selection || !props.value.selection.showEditor)
+          && (
+            renderPolygonControls({
+              annotation: props.value,
+              onSelectionComplete: this.onSelectionComplete,
+              onSelectionClear: this.onSelectionClear
             })
           )
         }

--- a/src/components/Content/index.js
+++ b/src/components/Content/index.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
+import { getHorizontallyCentralPoint, getVerticallyLowestPoint } from '../../utils/pointsUtils'
+import { PolygonSelector } from '../../selectors'
 
 const Container = styled.div`
   background: white;
@@ -10,7 +12,8 @@ const Container = styled.div`
     0px 3px 1px -2px rgba(0, 0, 0, 0.12);
   padding: 8px 16px;
   margin-top: 8px;
-  margin-left: 8px;
+  margin-left: -50%;
+  margin-right: 50%;
 `
 
 function Content (props) {
@@ -18,18 +21,21 @@ function Content (props) {
   if (!geometry) return null
 
   return (
-    <Container
+    <div
       style={{
         position: 'absolute',
-        left: `${geometry.x}%`,
-        top: `${geometry.y + geometry.height}%`,
+        left: ((geometry.type === PolygonSelector.TYPE) ? `${getHorizontallyCentralPoint(geometry.points)}%` : `${geometry.x}%`),
+        top: ((geometry.type === PolygonSelector.TYPE) ? `${getVerticallyLowestPoint(geometry.points)}%` : `${geometry.y + geometry.height}%`),
+        zIndex: 999,
         ...props.style
       }}
       className={props.className}
       geometry={geometry}
     >
-      {props.annotation.data && props.annotation.data.text}
-    </Container>
+      <Container>
+        {props.annotation.data && props.annotation.data.text}
+      </Container>
+    </div>
   )
 }
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import styled, { keyframes } from 'styled-components'
 import TextEditor from '../TextEditor'
+import { getHorizontallyCentralPoint, getVerticallyLowestPoint } from '../../utils/pointsUtils'
+import { PolygonSelector } from '../../selectors'
 
 const fadeInScale = keyframes`
   from {
@@ -23,9 +25,10 @@ const Container = styled.div`
     0px 3px 1px -2px rgba(0, 0, 0, 0.12);
   margin-top: 16px;
   transform-origin: top left;
-
   animation: ${fadeInScale} 0.31s cubic-bezier(0.175, 0.885, 0.32, 1.275);
   overflow: hidden;
+  margin-left: -50%;
+  margin-right: 50%
 `
 
 function Editor (props) {
@@ -33,27 +36,30 @@ function Editor (props) {
   if (!geometry) return null
 
   return (
-    <Container
+    <div
       className={props.className}
       style={{
         position: 'absolute',
-        left: `${geometry.x}%`,
-        top: `${geometry.y + geometry.height}%`,
+        left: ((geometry.type === PolygonSelector.TYPE) ? `${getHorizontallyCentralPoint(geometry.points)}%` : `${geometry.x}%`),
+        top: ((geometry.type === PolygonSelector.TYPE) ? `${getVerticallyLowestPoint(geometry.points)}%` : `${geometry.y + geometry.height}%`),
+        zIndex: 999,
         ...props.style
       }}
     >
-      <TextEditor
-        onChange={e => props.onChange({
-          ...props.annotation,
-          data: {
-            ...props.annotation.data,
-            text: e.target.value
-          }
-        })}
-        onSubmit={props.onSubmit}
-        value={props.annotation.data && props.annotation.data.text}
-      />
-    </Container>
+      <Container>
+        <TextEditor
+          onChange={e => props.onChange({
+            ...props.annotation,
+            data: {
+              ...props.annotation.data,
+              text: e.target.value
+            }
+          })}
+          onSubmit={props.onSubmit}
+          value={props.annotation.data && props.annotation.data.text}
+        />
+      </Container>
+    </div>
   )
 }
 

--- a/src/components/Polygon/index.css
+++ b/src/components/Polygon/index.css
@@ -1,0 +1,13 @@
+.Polygon-LineTo {
+  box-shadow: 0px 1px 1px 0 white;
+  box-sizing: border-box;
+  transition: box-shadow 0.21s ease-in-out;
+  z-index: -1;
+}
+
+.Polygon-LineToActive {
+  box-shadow: 0px 1px 1px 0 yellow;
+  box-sizing: border-box;
+  transition: box-shadow 0.21s ease-in-out;
+  z-index: -1;
+}

--- a/src/components/Polygon/index.js
+++ b/src/components/Polygon/index.js
@@ -16,12 +16,12 @@ const PointDot = styled.div`
 function edgesFromPoints(points) {
   if (!points || points.length < 3) return [];
 
-  const edges = [];
+  const edges = []
   for (let i = 0; i < points.length; ++i) {
     if (i + 1 === points.length) {
-      edges.push(Math.hypot(points[0].x-points[i].x, points[0].y-points[i].y));
+      edges.push(Math.hypot(points[0].x-points[i].x, points[0].y-points[i].y))
     } else {
-      edges.push(Math.hypot(points[i + 1].x-points[i].x, points[i + 1].y-points[i].y));
+      edges.push(Math.hypot(points[i + 1].x-points[i].x, points[i + 1].y-points[i].y))
     }
   }
 
@@ -42,11 +42,11 @@ function Polygon (props) {
       }}
     >
       {(geometry.points.length >= 3) && geometry.points.map((item,i) => { // Iterate over points to create the edge lines
-        let prevItem;
+        let prevItem
         if (i === 0) { // First point (links from last to first)
-          prevItem = geometry.points[geometry.points.length - 1];
+          prevItem = geometry.points[geometry.points.length - 1]
         } else {
-          prevItem = geometry.points[i - 1];
+          prevItem = geometry.points[i - 1]
         }
         return (
           // Note that each LineTo element must have a unique key (unique relative to the connected points)

--- a/src/components/Polygon/index.js
+++ b/src/components/Polygon/index.js
@@ -1,0 +1,87 @@
+import React from 'react'
+import LineTo from 'react-lineto'
+import styled from 'styled-components'
+import './index.css'
+
+const PointDot = styled.div`
+  background: black;
+  border-radius: 3px;
+  width: 6px;
+  height: 6px;
+  margin-left: -3px;
+  margin-top: -3px;
+  position: absolute;
+`
+
+function edgesFromPoints(points) {
+  if (!points || points.length < 3) return [];
+
+  const edges = [];
+  for (let i = 0; i < points.length; ++i) {
+    if (i + 1 === points.length) {
+      edges.push(Math.hypot(points[0].x-points[i].x, points[0].y-points[i].y));
+    } else {
+      edges.push(Math.hypot(points[i + 1].x-points[i].x, points[i + 1].y-points[i].y));
+    }
+  }
+
+  return edges;
+}
+
+function Polygon (props) {
+  const { geometry } = props.annotation
+  if (!geometry || !geometry.points || geometry.points.length === 0) return null
+
+  return (
+    <div
+      className={`linesContainer ${props.className}`}
+      style={{
+        width: '100%',
+        height: '100%',
+        ...props.style
+      }}
+    >
+      {(geometry.points.length >= 3) && geometry.points.map((item,i) => { // Iterate over points to create the edge lines
+        let prevItem;
+        if (i === 0) { // First point (links from last to first)
+          prevItem = geometry.points[geometry.points.length - 1];
+        } else {
+          prevItem = geometry.points[i - 1];
+        }
+        return (
+          // Note that each LineTo element must have a unique key (unique relative to the connected points)
+          <LineTo
+            key={i + "_" + item.x + "_" + item.y + "_" + prevItem.x + "_" + prevItem.y}
+            from="linesContainer"
+            fromAnchor={item.x + "% " + item.y + "%"}
+            to="linesContainer"
+            toAnchor={prevItem.x + "% " + prevItem.y + "%"}
+            borderColor={'black'}
+            borderStyle={'dashed'}
+            borderWidth={2}
+            className={(!props.active) ? "Polygon-LineTo" : "Polygon-LineToActive"}
+          />
+        )
+      })}
+      {geometry.points.map((item,i) => { // Iterate over points to points
+        return (
+          // Note that each LineTo element must have a unique key (unique relative to the point)
+          <PointDot
+            key={i + "_" + item.x + "_" + item.y}
+            style={{
+              left: item.x + "% ",
+              top: item.y + "%"
+            }}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+Polygon.defaultProps = {
+  className: '',
+  style: {}
+}
+
+export default Polygon

--- a/src/components/PolygonControls/index.js
+++ b/src/components/PolygonControls/index.js
@@ -1,0 +1,83 @@
+import React from 'react'
+import styled, { keyframes } from 'styled-components'
+import { getHorizontallyCentralPoint, getVerticallyLowestPoint } from '../../utils/pointsUtils'
+
+const fadeInScale = keyframes`
+  from {
+    opacity: 0;
+    transform: scale(0);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+`
+
+const Container = styled.div`
+  background: white;
+  border-radius: 2px;
+  box-shadow:
+    0px 1px 5px 0px rgba(0, 0, 0, 0.2),
+    0px 2px 2px 0px rgba(0, 0, 0, 0.14),
+    0px 3px 1px -2px rgba(0, 0, 0, 0.12);
+  margin-top: 16px;
+  transform-origin: top left;
+
+  animation: ${fadeInScale} 0.31s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  overflow: hidden;
+  margin-left: -50%;
+  margin-right: 50%
+`
+
+const Button = styled.div`
+  background: whitesmoke;
+  border: 0;
+  box-sizing: border-box;
+  color: #363636;
+  cursor: pointer;
+  font-size: 1rem;
+  margin: 0;
+  outline: 0;
+  padding: 8px 16px;
+  text-align: center;
+  text-shadow: 0 1px 0 rgba(0,0,0,0.1);
+  width: 100%;
+
+  transition: background 0.21s ease-in-out;
+
+  &:focus, &:hover {
+    background: #eeeeee;
+  }
+`
+
+function PolygonControls (props) {
+  const { geometry } = props.annotation
+  // Only show polygon controls if there are at least three points set
+  if (!geometry || !geometry.points || geometry.points.length < 3) return null
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        left: `${getHorizontallyCentralPoint(geometry.points)}%`,
+        top: `${getVerticallyLowestPoint(geometry.points)}%`,
+        ...props.style
+      }}
+    >
+      <Container
+        className={props.className}
+      >
+        <Button onClick={props.onSelectionClear}>Clear</Button>
+        <Button onClick={props.onSelectionComplete}>Done</Button>
+      </Container>
+    </div>
+  )
+}
+
+PolygonControls.defaultProps = {
+  className: '',
+  style: {}
+}
+
+export default PolygonControls

--- a/src/components/defaultProps.js
+++ b/src/components/defaultProps.js
@@ -2,16 +2,19 @@ import React from 'react'
 
 import Point from './Point'
 import Editor from './Editor'
+import PolygonControls from './PolygonControls';
 import FancyRectangle from './FancyRectangle'
 import Rectangle from './Rectangle'
 import Oval from './Oval'
+import Polygon from './Polygon'
 import Content from './Content'
 import Overlay from './Overlay'
 
 import {
   RectangleSelector,
   PointSelector,
-  OvalSelector
+  OvalSelector,
+  PolygonSelector
 } from '../selectors'
 
 export default {
@@ -22,7 +25,8 @@ export default {
   selectors: [
     RectangleSelector,
     PointSelector,
-    OvalSelector
+    OvalSelector,
+    PolygonSelector
   ],
   disableAnnotation: false,
   disableSelector: false,
@@ -49,6 +53,12 @@ export default {
             annotation={annotation}
           />
         )
+      case PolygonSelector.TYPE:
+        return (
+          <Polygon
+            annotation={annotation}
+          />
+        )
       default:
         return null
     }
@@ -58,6 +68,13 @@ export default {
       annotation={annotation}
       onChange={onChange}
       onSubmit={onSubmit}
+    />
+  ),
+  renderPolygonControls: ({ annotation, onSelectionComplete, onSelectionClear }) => (
+    <PolygonControls
+      annotation={annotation}
+      onSelectionComplete={onSelectionComplete}
+      onSelectionClear={onSelectionClear}
     />
   ),
   renderHighlight: ({ key, annotation, active }) => {
@@ -81,6 +98,14 @@ export default {
       case OvalSelector.TYPE:
         return (
           <Oval
+            key={key}
+            annotation={annotation}
+            active={active}
+          />
+        )
+      case PolygonSelector.TYPE:
+        return (
+          <Polygon
             key={key}
             annotation={annotation}
             active={active}

--- a/src/components/defaultProps.js
+++ b/src/components/defaultProps.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import Point from './Point'
 import Editor from './Editor'
-import PolygonControls from './PolygonControls';
+import PolygonControls from './PolygonControls'
 import FancyRectangle from './FancyRectangle'
 import Rectangle from './Rectangle'
 import Oval from './Oval'
@@ -127,6 +127,12 @@ export default {
         return (
           <Overlay>
             Click to Annotate
+          </Overlay>
+        )
+      case PolygonSelector.TYPE:
+        return (
+          <Overlay>
+            Click to Add Points to Annotation
           </Overlay>
         )
       default:

--- a/src/hocs/PolygonSelector.js
+++ b/src/hocs/PolygonSelector.js
@@ -1,5 +1,5 @@
-const inside = require('point-in-polygon');
-import { polygon } from 'polygon-tools';
+var PolygonLookup = require('polygon-lookup')
+import { polygon } from 'polygon-tools'
 
 import { getHorizontallyCentralPoint, getVerticallyLowestPoint } from '../utils/pointsUtils'
 
@@ -10,18 +10,67 @@ const getCoordPercentage = (e) => ({
 
 export const TYPE = 'POLYGON'
 
+/* 
+ * This function checks if the argument pointToCheck exists on the line created between pointA and pointB.
+ * All point arguments are represented as two element arrays (e.g.: [10, 15]).
+ */
+function isPointOnLine (pointA, pointB, pointToCheck) {
+  return (Math.hypot(pointToCheck[0]-pointA[0], pointToCheck[1]-pointA[1])
+         + Math.hypot(pointB[0]-pointToCheck[0], pointB[1]-pointToCheck[1])
+         === Math.hypot(pointB[0]-pointA[0], pointB[1]-pointA[1]))
+}
+
+/* 
+ * This function checks if the point [x, y] exists on the edge of the polygon created by points polygonPoints.
+ * The argument polygonPoints is an array of objects (e.g.: [{x: 10, y: 15}, ...]).
+ */
+function isPointOnPolygonEdge ({ x, y }, polygonPoints) {
+  if (!polygonPoints || polygonPoints.length < 3 || !x || !y) { return false }
+
+  for (let i = 0; i < polygonPoints.length - 1; ++i) {
+    if (i === 0) { // First point
+      if (isPointOnLine(polygonPoints[0], polygonPoints[polygonPoints.length - 1], [x, y])) {
+        return true
+      }
+    } else {
+      if (isPointOnLine(polygonPoints[i], polygonPoints[i + 1], [x, y])) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
 export function intersects ({ x, y }, geometry) {
-  if (!geometry || !geometry.points || geometry.points.length < 3) return false;
+  if (!geometry || !geometry.points || geometry.points.length < 3) return false
 
-  const pointsAsArrays = geometry.points.map(point => [point.x, point.y]);
+  // Switch to point array format (e.g.: [{x: 10, y: 15}, ...] -> [[10, 15], ...])
+  const pointsAsArrays = geometry.points.map(point => [point.x, point.y])
 
-  return inside([x, y], pointsAsArrays);
+  // Setup GeoJSON json format
+  const featureCollection = {
+    type: 'FeatureCollection',
+    features: [{
+      geometry: {
+        type: 'Polygon',
+        coordinates: [ pointsAsArrays ]
+      }
+    }]
+  }
+
+  // Determine if point is inside polygon
+  const lookup = new PolygonLookup(featureCollection)
+  const poly = lookup.search(x, y)
+
+  // Return whether the point is inside the polygon (poly equals undefined if not) or if the
+  // point is on the edge (isPointOnPolygonEdge function call)
+  return (poly !== undefined || isPointOnPolygonEdge({x, y}, pointsAsArrays))
 }
 
 export function area (geometry) {
-  if (!geometry || !geometry.points || geometry.points.length < 3) return 0;
+  if (!geometry || !geometry.points || geometry.points.length < 3) return 0
 
-  return polygon.area(geometry.points);
+  return polygon.area(geometry.points.map(point => [point.x, point.y]))
 }
 
 export const methods = {
@@ -47,7 +96,7 @@ export const methods = {
   },
 
   onMouseUp (annotation, e) {
-    const coordOfClick = getCoordPercentage(e);
+    const coordOfClick = getCoordPercentage(e)
 
     return {
       ...annotation,

--- a/src/hocs/PolygonSelector.js
+++ b/src/hocs/PolygonSelector.js
@@ -1,0 +1,75 @@
+const inside = require('point-in-polygon');
+import { polygon } from 'polygon-tools';
+
+import { getHorizontallyCentralPoint, getVerticallyLowestPoint } from '../utils/pointsUtils'
+
+const getCoordPercentage = (e) => ({
+  x: e.nativeEvent.offsetX / e.currentTarget.offsetWidth * 100,
+  y: e.nativeEvent.offsetY / e.currentTarget.offsetHeight * 100
+})
+
+export const TYPE = 'POLYGON'
+
+export function intersects ({ x, y }, geometry) {
+  if (!geometry || !geometry.points || geometry.points.length < 3) return false;
+
+  const pointsAsArrays = geometry.points.map(point => [point.x, point.y]);
+
+  return inside([x, y], pointsAsArrays);
+}
+
+export function area (geometry) {
+  if (!geometry || !geometry.points || geometry.points.length < 3) return 0;
+
+  return polygon.area(geometry.points);
+}
+
+export const methods = {
+  onSelectionComplete (annotation) {
+    return {
+      ...annotation,
+      selection: {
+        ...annotation.selection,
+        showEditor: true,
+        mode: 'EDITING'
+      }
+    }
+  },
+
+  onSelectionClear (annotation) {
+    return {
+      ...annotation,
+      geometry: {
+        ...annotation.geometry,
+        points: []
+      }
+    }
+  },
+
+  onMouseUp (annotation, e) {
+    const coordOfClick = getCoordPercentage(e);
+
+    return {
+      ...annotation,
+      geometry: {
+        ...annotation.geometry,
+        type: TYPE,
+        points: (!annotation.geometry ? [coordOfClick] : [
+          ...annotation.geometry.points,
+          coordOfClick
+        ])
+      },
+      selection: {
+        ...annotation.selection,
+        mode: 'SELECTING'
+      }
+    }
+  }
+}
+
+export default {
+  TYPE,
+  intersects,
+  area,
+  methods
+}

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,3 +1,4 @@
 export { default as RectangleSelector } from './hocs/RectangleSelector'
 export { default as PointSelector } from './hocs/PointSelector'
 export { default as OvalSelector } from './hocs/OvalSelector'
+export { default as PolygonSelector } from './hocs/PolygonSelector'

--- a/src/utils/pointsUtils.js
+++ b/src/utils/pointsUtils.js
@@ -1,0 +1,23 @@
+/*
+ * This util file contains functions for getting different kinds of horizontal/vertical
+ * points given an array of points (e.g.: [{x: 4, y: 87}, {x: 99, y:7}, ...]).
+ */
+
+/*
+ * This function returns the horizontally central x-value (number return type), defined
+ * as the mean of the smallest and largest x-values.
+ */
+export function getHorizontallyCentralPoint(points) {
+  const leftMostHorizontalPoint = points.reduce((prev, curr) => (curr.x < prev.x ? curr : prev)).x
+  const rightMostHorizontalPoint = points.reduce((prev, curr) => (curr.x > prev.x ? curr : prev)).x
+
+  return leftMostHorizontalPoint + Math.round((rightMostHorizontalPoint - leftMostHorizontalPoint) / 2)
+}
+
+/*
+ * This function returns the vertically lowest y-value (number return type), defined
+ * as the largest y-value.
+ */
+export function getVerticallyLowestPoint(points) {
+  return points.reduce((prev, curr) => (curr.y > prev.y ? curr : prev)).y
+}

--- a/tests/selectors/PolygonSelector.spec.js
+++ b/tests/selectors/PolygonSelector.spec.js
@@ -1,0 +1,70 @@
+import { mount } from 'enzyme'
+import { expect } from 'chai'
+import React from 'react'
+
+import { PolygonSelector as selector } from '../../src/selectors'
+
+function createPolygon ({ points } = { points: [{x: 10, y: 10}, {x: 90, y: 10}, {x: 50, y: 90}] }) {
+  return {
+    points
+  }
+}
+
+describe('PolygonSelector', () => {
+  describe('TYPE', () => {
+    it('should be a defined string', () => {
+      expect(selector.TYPE).to.be.a('string')
+    })
+  })
+
+  describe('intersects', () => {
+    it('should return true when point is on top left of geometry', () => {
+      expect(
+        selector.intersects({ x: 10, y: 10 }, createPolygon())
+      ).to.be.true
+    })
+    it('should return true when point is on top right of geometry', () => {
+      expect(
+        selector.intersects({ x: 90, y: 10 }, createPolygon())
+      ).to.be.true
+    })
+    it('should return true when point is on bottom left of geometry', () => {
+      expect(
+        selector.intersects({ x: 40, y: 60 }, createPolygon())
+      ).to.be.true
+    })
+    it('should return true when point is on bottom right of geometry', () => {
+      expect(
+        selector.intersects({ x: 60, y: 60 }, createPolygon())
+      ).to.be.true
+    })
+    it('should return true when point is on bottom center of geometry', () => {
+      expect(
+        selector.intersects({ x: 50, y: 90 }, createPolygon())
+      ).to.be.true
+    })
+    it('should return true when point is inside geometry', () => {
+      expect(
+        selector.intersects({ x: 50, y: 50 }, createPolygon())
+      ).to.be.true
+    })
+    it('should return false when point is outside of geometry', () => {
+      expect(selector.intersects({ x: 0, y: 0 }, createPolygon())).to.be.false
+      expect(selector.intersects({ x: 100, y: 0 }, createPolygon())).to.be.false
+      expect(selector.intersects({ x: 0, y: 100 }, createPolygon())).to.be.false
+      expect(selector.intersects({ x: 100, y: 100 }, createPolygon())).to.be.false
+      expect(selector.intersects({ x: 10, y: 20 }, createPolygon())).to.be.false
+      expect(selector.intersects({ x: 90, y: 20 }, createPolygon())).to.be.false
+    })
+  })
+
+  describe('area', () => {
+    it('should return geometry area', () => {
+      expect(selector.area(createPolygon())).to.equal(3200)
+    })
+  })
+
+  describe('methods', () => {
+    xit('should be defined')
+  })
+})


### PR DESCRIPTION
This pull request adds support for a `PolygonSelector`, enabling annotation of polygons by adding points to the image. The pull request includes an example of the `PolygonSelector` in action on the demos page, as well as karma tests of the new selector functionality.