### PR TITLE
Fix for inconsistent values from nativeEvent.offsetX and Y

### DIFF
--- a/src/hocs/OvalSelector.js
+++ b/src/hocs/OvalSelector.js
@@ -1,9 +1,6 @@
-const square = n => Math.pow(n, 2)
+import { getCoordPercentage } from '../utils/offsetCoordinates';
 
-const getCoordPercentage = (e) => ({
-  x: e.nativeEvent.offsetX / e.currentTarget.offsetWidth * 100,
-  y: e.nativeEvent.offsetY / e.currentTarget.offsetHeight * 100
-})
+const square = n => Math.pow(n, 2)
 
 export const TYPE = 'OVAL'
 

--- a/src/hocs/PointSelector.js
+++ b/src/hocs/PointSelector.js
@@ -1,9 +1,5 @@
+import { getCoordPercentage } from '../utils/offsetCoordinates';
 const MARGIN = 6
-
-const getCoordPercentage = (e) => ({
-  x: e.nativeEvent.offsetX / e.currentTarget.offsetWidth * 100,
-  y: e.nativeEvent.offsetY / e.currentTarget.offsetHeight * 100
-})
 
 const marginToPercentage = (container) => ({
   marginX: MARGIN / container.width * 100,

--- a/src/hocs/RectangleSelector.js
+++ b/src/hocs/RectangleSelector.js
@@ -1,7 +1,4 @@
-const getCoordPercentage = (e) => ({
-  x: e.nativeEvent.offsetX / e.currentTarget.offsetWidth * 100,
-  y: e.nativeEvent.offsetY / e.currentTarget.offsetHeight * 100
-})
+import { getCoordPercentage } from '../utils/offsetCoordinates';
 
 export const TYPE = 'RECTANGLE'
 

--- a/src/utils/offsetCoordinates.js
+++ b/src/utils/offsetCoordinates.js
@@ -1,0 +1,30 @@
+function getOffsetCoordinates(e, container) {
+    // nativeEvent.offsetX gives inconsistent results when dragging
+    // up and to the left rather than the more natural down and to the
+    // right. The reason could be browser implementation (it is still experimental)
+    // or it could be that nativeEvent offsets are based on target rather than
+    // currentTarget.
+    // To keep consistent behavior of the selector use the bounding client rect.
+    const rect = container.getBoundingClientRect();
+    const offsetX = e.clientX - rect.x;
+    const offsetY = e.clientY - rect.y;
+    return ({
+        offsetX: offsetX,
+        offsetY: offsetY
+    });
+}
+
+function getOffsetCoordPercentage(e, container) {
+    const { offsetX, offsetY } = getOffsetCoordinates(e, container);
+    return {
+        x: offsetX / container.offsetWidth * 100,
+        y: offsetY / container.offsetHeight * 100
+    };
+}
+
+function getCoordPercentage(e) {    
+    return getOffsetCoordPercentage(e, e.currentTarget);
+}
+
+
+export { getOffsetCoordPercentage, getCoordPercentage };

--- a/src/utils/offsetCoordinates.js
+++ b/src/utils/offsetCoordinates.js
@@ -1,4 +1,4 @@
-function getOffsetCoordinates(e, container) {
+function getOffsetCoordPercentage(e, container) {
     // nativeEvent.offsetX gives inconsistent results when dragging
     // up and to the left rather than the more natural down and to the
     // right. The reason could be browser implementation (it is still experimental)
@@ -8,21 +8,14 @@ function getOffsetCoordinates(e, container) {
     const rect = container.getBoundingClientRect();
     const offsetX = e.clientX - rect.x;
     const offsetY = e.clientY - rect.y;
-    return ({
-        offsetX: offsetX,
-        offsetY: offsetY
-    });
-}
 
-function getOffsetCoordPercentage(e, container) {
-    const { offsetX, offsetY } = getOffsetCoordinates(e, container);
     return {
-        x: offsetX / container.offsetWidth * 100,
-        y: offsetY / container.offsetHeight * 100
+        x: offsetX / rect.width * 100,
+        y: offsetY / rect.height * 100
     };
 }
 
-function getCoordPercentage(e) {    
+function getCoordPercentage(e) {
     return getOffsetCoordPercentage(e, e.currentTarget);
 }
 

--- a/src/utils/withRelativeMousePos.js
+++ b/src/utils/withRelativeMousePos.js
@@ -1,4 +1,5 @@
 import React, { PureComponent as Component } from 'react'
+import { getOffsetCoordPercentage } from './offsetCoordinates';
 
 const withRelativeMousePos = (key = 'relativeMousePos') => DecoratedComponent => {
   class WithRelativeMousePos extends Component {
@@ -9,10 +10,8 @@ const withRelativeMousePos = (key = 'relativeMousePos') => DecoratedComponent =>
     }
 
     onMouseMove = (e) => {
-      this.setState({
-        x: (e.nativeEvent.offsetX / this.container.width) * 100,
-        y: (e.nativeEvent.offsetY / this.container.height) * 100,
-      })
+      const xystate = getOffsetCoordPercentage(e, this.container);
+      this.setState(xystate);
     }
 
     onMouseLeave = (e) => {


### PR DESCRIPTION
I was exploring a change to address issue #14 and ran into an issue with the selector that was caused by the use of offsetX and offsetY in getCoordPercentage.

MouseEvent offsets give inconsistent results when dragging up and to the left rather than the more natural down and to the right. The reason could be browser implementation (it is still experimental) or it could be that nativeEvent offsets are based on target rather than currentTarget, I don't know.

To keep consistent behavior with the selector use the bounding client rect to calculate offset values for the current element.