### PR TITLE
Adds a prop for input text area

### DIFF
--- a/src/components/Annotation.js
+++ b/src/components/Annotation.js
@@ -84,7 +84,9 @@ export default compose(
 
     disableOverlay: T.bool,
     renderOverlay: T.func.isRequired,
-    allowTouch: T.bool
+    allowTouch: T.bool,
+
+    renderInputArea: T.func
   }
 
   static defaultProps = defaultProps
@@ -311,7 +313,8 @@ export default compose(
             renderEditor({
               annotation: props.value,
               onChange: props.onChange,
-              onSubmit: this.onSubmit
+              onSubmit: this.onSubmit,
+              renderInputArea: props.renderInputArea
             })
           )
         }

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -52,6 +52,7 @@ function Editor (props) {
         })}
         onSubmit={props.onSubmit}
         value={props.annotation.data && props.annotation.data.text}
+        renderInputArea={props.renderInputArea}
       />
     </Container>
   )

--- a/src/components/TextEditor/index.js
+++ b/src/components/TextEditor/index.js
@@ -38,14 +38,12 @@ function TextEditor (props) {
   return (
     <React.Fragment>
       <Inner>
-        <textarea
-          placeholder='Write description'
-          onFocus={props.onFocus}
-          onBlur={props.onBlur}
-          onChange={props.onChange}
-          value={props.value}
-        >
-        </textarea>
+        {props.renderInputArea({
+          onFocus: props.onFocus,
+          onBlur: props.onBlur,
+          onChange: props.onChange,
+          value: props.value
+        })}
       </Inner>
       {props.value && (
         <Button

--- a/src/components/defaultProps.js
+++ b/src/components/defaultProps.js
@@ -111,5 +111,15 @@ export default {
           </Overlay>
         )
     }
-  }
+  },
+  renderInputArea: ({onFocus, onBlur, onChange, value}) => (
+    <textarea
+      placeholder="Write description"
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onChange={onChange}
+      value={value}
+    >
+    </textarea>
+  )
 }


### PR DESCRIPTION
# Use Case
I wanted to annotate data, but I wanted a dropdown instead of a text area.

I observed that it was not possible to change the text area without implementing the complete `TextEditor` component.

This change now allows me to provide a React Component as a prop.

```js
<Annotation
  src={img}
  annotations={annotations}
  value={annotation}
  onChange={setCurrentAnnotation}
  onSubmit={onSubmit}
  renderInputArea={props => <LabelInputArea {...props} />}
/>
```

I have not written any tests yet.