### PR TITLE
Expose types correctly and add support for generic annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "src/types/index.d.ts"
   ],
   "scripts": {
+    "prepare": "nwb build-react-component",
     "build": "nwb build-react-component",
     "deploy": "gh-pages -d demo/dist",
     "clean": "nwb clean-module && nwb clean-demo",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "css",
     "es",
     "lib",
-    "umd"
+    "umd",
+    "src/types/index.d.ts"
   ],
   "scripts": {
     "build": "nwb build-react-component",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "react-image-annotation React component",
   "author": "Arian Allenson Valdez <arianallensonv@gmail.com> (http://arianv.com/)",
   "main": "lib/index.js",
+  "types": "src/types/index.d.ts",
   "module": "es/index.js",
   "files": [
     "css",

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -35,7 +35,7 @@ declare module "react-image-annotation" {
       id?: number;
     };
   }
-  interface IAnnotationProps {
+  interface IAnnotationProps<T> {
     src: string;
     alt?: string;
     innerRef?: (e: any) => any;
@@ -44,45 +44,53 @@ declare module "react-image-annotation" {
     onMouseMove?: (e: React.MouseEvent) => any;
     onClick?: (e: React.MouseEvent) => any;
 
-    annotations: IAnnotation[];
+    annotations: T[];
     type?: string;
     selectors?: ISelector[];
 
-    value: IAnnotation | {};
+    value: T | {};
     onChange?: (e: any) => any;
     onSubmit?: (e: any) => any;
 
-    activeAnnotationComparator?: (annotation: IAnnotation) => boolean;
-    activeAnnotations?: IAnnotation[];
+    activeAnnotationComparator?: (annotation: T) => boolean;
+    activeAnnotations?: T[];
 
     disableAnnotation?: boolean;
     disableSelector?: boolean;
-    renderSelector?: (
-      { annotation, active }: { annotation: IAnnotation; active: boolean }
-    ) => any;
+    renderSelector?: ({
+      annotation,
+      active,
+    }: {
+      annotation: T;
+      active: boolean;
+    }) => any;
     disableEditor?: boolean;
-    renderEditor?: (
-      {
-        annotation,
-        onChange,
-        onSubmit
-      }: {
-        annotation: IAnnotation;
-        onChange: (annotation: IAnnotation | {}) => any;
-        onSubmit: (e?: any) => any;
-      }
-    ) => any;
+    renderEditor?: ({
+      annotation,
+      onChange,
+      onSubmit,
+    }: {
+      annotation: T;
+      onChange: (annotation: T | {}) => any;
+      onSubmit: (e?: any) => any;
+    }) => any;
 
-    renderHighlight?: (
-      { annotation, active }: { annotation: IAnnotation; active: boolean }
-    ) => any;
-    renderContent?: ({ annotation }: { annotation: IAnnotation }) => any;
+    renderHighlight?: ({
+      key,
+      annotation,
+      active,
+    }: {
+      key: string;
+      annotation: T;
+      active: boolean;
+    }) => any;
+    renderContent?: ({ annotation }: { annotation: T }) => any;
 
     disableOverlay?: boolean;
     renderOverlay?: () => any;
     allowTouch: boolean;
   }
 
-  class Annotation extends React.Component<IAnnotationProps, {}> {}
+  class Annotation<T> extends React.Component<IAnnotationProps<T>, {}> {}
   export default Annotation;
 }


### PR DESCRIPTION
Fixed 2 things:
1. The TypeScript definitions were not being exposed correctly, the change to package.json fixes that. I followed the instructions at https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html.
2. Expose the `key` property that is [provided to `renderHighlight`](https://github.com/Secretmapper/react-image-annotation/blob/master/src/components/Annotation.js#L268-L272) -- this definition was out of date.

Added new:
1. Support for generic `IAnnotation` objects so you can use your own version of the Annotation object and include your own data outside of just text and an id. You use it like this:
    ```ts
    import { IAnnotation } from 'react-image-annotation'

    export interface MyAnnotation extends Omit<IAnnotation, 'data'> {
      data: {
        id?: string
        updatedAt: Date
        type: string
        userVisibleName: string
        metadata: Record<string, unknown>
      }
    }
    ```